### PR TITLE
Add method to access url

### DIFF
--- a/src/Fonts.php
+++ b/src/Fonts.php
@@ -44,6 +44,15 @@ class Fonts implements Htmlable
         HTML);
     }
 
+    public function url(): string
+    {
+        if (! $this->localizedUrl) {
+            return $this->googleFontsUrl;
+        }
+
+        return $this->localizedUrl;
+    }
+
     public function toHtml(): HtmlString
     {
         return $this->preferInline ? $this->inline() : $this->link();


### PR DESCRIPTION
This PR adds a method `url()` which enables you to access the url of the font stored locally (or else the fallback).
Sometimes this is needed, for example to use this package with the Filament admin panel: https://filamentphp.com/docs/2.x/admin/appearance#including-frontend-assets.

```php
Filament::registerStyles([
    app(GoogleFonts::class)->load()->url(),
]);
```