### PR TITLE
feat: add blocking option

### DIFF
--- a/config/google-fonts.php
+++ b/config/google-fonts.php
@@ -29,6 +29,13 @@ return [
     'inline' => true,
 
     /*
+     * By default, stylesheets are blocking and the page won't render before
+     * the fonts are loaded. However, we can speed up the initial rendering 
+     * by applying fonts after the page has loaded.
+     */
+    'blocking' => true,
+
+    /*
      * When something goes wrong fonts are loaded directly from Google.
      * With fallback disabled, this package will throw an exception.
      */

--- a/src/GoogleFonts.php
+++ b/src/GoogleFonts.php
@@ -118,6 +118,10 @@ class GoogleFonts
 
     protected function path(string $url, string $path = ''): string
     {
-        return $this->path . '/' . substr(md5($url), 0, 10) . '/' . $path;
+        return join('/', array_filter([
+            $this->path,
+            substr(md5($url), 0, 10),
+            $path
+        ]));
     }
 }

--- a/src/GoogleFonts.php
+++ b/src/GoogleFonts.php
@@ -14,6 +14,7 @@ class GoogleFonts
         protected Filesystem $filesystem,
         protected string $path,
         protected bool $inline,
+        protected bool $blocking,
         protected bool $fallback,
         protected string $userAgent,
         protected array $fonts,
@@ -62,6 +63,7 @@ class GoogleFonts
             localizedUrl: $this->filesystem->url($this->path($url, 'fonts.css')),
             localizedCss: $localizedCss,
             preferInline: $this->inline,
+            blocking: $this->blocking,
         );
     }
 
@@ -95,6 +97,7 @@ class GoogleFonts
             localizedUrl: $this->filesystem->url($this->path($url, 'fonts.css')),
             localizedCss: $localizedCss,
             preferInline: $this->inline,
+            blocking: $this->blocking,
         );
     }
 

--- a/src/GoogleFontsServiceProvider.php
+++ b/src/GoogleFontsServiceProvider.php
@@ -26,6 +26,7 @@ class GoogleFontsServiceProvider extends PackageServiceProvider
                 filesystem: $app->make(FilesystemManager::class)->disk(config('google-fonts.disk')),
                 path: config('google-fonts.path'),
                 inline: config('google-fonts.inline'),
+                blocking: config('google-fonts.blocking', true),
                 fallback: config('google-fonts.fallback'),
                 userAgent: config('google-fonts.user_agent'),
                 fonts: config('google-fonts.fonts'),

--- a/tests/GoogleFontsTest.php
+++ b/tests/GoogleFontsTest.php
@@ -60,7 +60,6 @@ class GoogleFontsTest extends TestCase
     {
         config()->set('google-fonts.blocking', false);
 
-        app()->forgetInstance(GoogleFonts::class);
         $fonts = app(GoogleFonts::class)->load('inter', forceDownload: true);
 
         $this->assertMatchesHtmlSnapshot((string)$fonts->link());

--- a/tests/GoogleFontsTest.php
+++ b/tests/GoogleFontsTest.php
@@ -31,7 +31,7 @@ class GoogleFontsTest extends TestCase
 
         $this->assertMatchesHtmlSnapshot((string)$fonts->link());
         $this->assertMatchesHtmlSnapshot((string)$fonts->inline());
-        $this->assertEquals($fullCssPath, $fonts->url());
+        $this->assertEquals($this->disk()->url($expectedFileName), $fonts->url());
     }
 
     /** @test */

--- a/tests/GoogleFontsTest.php
+++ b/tests/GoogleFontsTest.php
@@ -54,4 +54,16 @@ class GoogleFontsTest extends TestCase
         $this->assertEquals($fallback, (string)$fonts->inline());
         $this->assertEquals('moo', $fonts->url());
     }
+
+    /** @test */
+    public function it_renders_non_blocking_tags()
+    {
+        config()->set('google-fonts.blocking', false);
+
+        app()->forgetInstance(GoogleFonts::class);
+        $fonts = app(GoogleFonts::class)->load('inter', forceDownload: true);
+
+        $this->assertMatchesHtmlSnapshot((string)$fonts->link());
+        $this->assertMatchesHtmlSnapshot((string)$fonts->inline());
+    }
 }

--- a/tests/__snapshots__/GoogleFontsTest__it_loads_google_fonts__2.html
+++ b/tests/__snapshots__/GoogleFontsTest__it_loads_google_fonts__2.html
@@ -1,2 +1,2 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
-<html><head><link href="/storage//952ee985ef/fonts.css" rel="stylesheet" type="text/css"></head></html>
+<html><head><link href="/storage/952ee985ef/fonts.css" rel="stylesheet" type="text/css"></head></html>

--- a/tests/__snapshots__/GoogleFontsTest__it_loads_google_fonts__3.html
+++ b/tests/__snapshots__/GoogleFontsTest__it_loads_google_fonts__3.html
@@ -5,7 +5,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2jl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2jl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 /* cyrillic */
@@ -14,7 +14,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma0zl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma0zl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 /* greek-ext */
@@ -23,7 +23,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2zl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2zl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+1F00-1FFF;
 }
 /* greek */
@@ -32,7 +32,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma1pl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma1pl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0370-03FF;
 }
 /* vietnamese */
@@ -41,7 +41,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2pl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2pl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
 /* latin-ext */
@@ -50,7 +50,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma25l7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma25l7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
@@ -59,7 +59,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma1zl7w0q5nw.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma1zl7w0q5nw.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 /* cyrillic-ext */
@@ -68,7 +68,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2jl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2jl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 /* cyrillic */
@@ -77,7 +77,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma0zl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma0zl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 /* greek-ext */
@@ -86,7 +86,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2zl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2zl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+1F00-1FFF;
 }
 /* greek */
@@ -95,7 +95,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma1pl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma1pl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0370-03FF;
 }
 /* vietnamese */
@@ -104,7 +104,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2pl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2pl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
 /* latin-ext */
@@ -113,7 +113,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma25l7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma25l7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
@@ -122,7 +122,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma1zl7w0q5nw.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma1zl7w0q5nw.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 </style></head></html>

--- a/tests/__snapshots__/GoogleFontsTest__it_renders_non_blocking_tags__1.html
+++ b/tests/__snapshots__/GoogleFontsTest__it_renders_non_blocking_tags__1.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<html><head>
+<link href="/storage//952ee985ef/fonts.css" rel="preload" as="style">
+    <link href="/storage//952ee985ef/fonts.css" rel="stylesheet" media="print" type="text/css" onload="this.onload=null;this.removeAttribute('media');">
+</head></html>

--- a/tests/__snapshots__/GoogleFontsTest__it_renders_non_blocking_tags__1.html
+++ b/tests/__snapshots__/GoogleFontsTest__it_renders_non_blocking_tags__1.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
 <html><head>
-<link href="/storage//952ee985ef/fonts.css" rel="preload" as="style">
-    <link href="/storage//952ee985ef/fonts.css" rel="stylesheet" media="print" type="text/css" onload="this.onload=null;this.removeAttribute('media');">
+<link href="/storage/952ee985ef/fonts.css" rel="preload" as="style">
+    <link href="/storage/952ee985ef/fonts.css" rel="stylesheet" media="print" type="text/css" onload="this.onload=null;this.removeAttribute('media');">
 </head></html>

--- a/tests/__snapshots__/GoogleFontsTest__it_renders_non_blocking_tags__2.html
+++ b/tests/__snapshots__/GoogleFontsTest__it_renders_non_blocking_tags__2.html
@@ -5,7 +5,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2jl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2jl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 /* cyrillic */
@@ -14,7 +14,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma0zl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma0zl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 /* greek-ext */
@@ -23,7 +23,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2zl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2zl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+1F00-1FFF;
 }
 /* greek */
@@ -32,7 +32,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma1pl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma1pl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0370-03FF;
 }
 /* vietnamese */
@@ -41,7 +41,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2pl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2pl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
 /* latin-ext */
@@ -50,7 +50,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma25l7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma25l7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
@@ -59,7 +59,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma1zl7w0q5nw.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma1zl7w0q5nw.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 /* cyrillic-ext */
@@ -68,7 +68,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2jl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2jl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 /* cyrillic */
@@ -77,7 +77,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma0zl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma0zl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 /* greek-ext */
@@ -86,7 +86,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2zl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2zl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+1F00-1FFF;
 }
 /* greek */
@@ -95,7 +95,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma1pl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma1pl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0370-03FF;
 }
 /* vietnamese */
@@ -104,7 +104,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2pl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2pl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
 /* latin-ext */
@@ -113,7 +113,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma25l7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma25l7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
@@ -122,7 +122,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma1zl7w0q5nw.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma1zl7w0q5nw.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 </style></head></html>

--- a/tests/__snapshots__/GoogleFontsTest__it_renders_non_blocking_tags__2.html
+++ b/tests/__snapshots__/GoogleFontsTest__it_renders_non_blocking_tags__2.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
-<html><head><style type="text/css">/* cyrillic-ext */
+<html><head><style media="print" type="text/css" onload="this.onload=null;this.removeAttribute('media');">/* cyrillic-ext */
 @font-face {
   font-family: 'Inter';
   font-style: normal;

--- a/tests/__snapshots__/files/GoogleFontsTest__it_loads_google_fonts__1.css
+++ b/tests/__snapshots__/files/GoogleFontsTest__it_loads_google_fonts__1.css
@@ -4,7 +4,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv7ucc73fwrk3iltehus-fvqtmwcp50knma2jl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2jl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 /* cyrillic */
@@ -13,7 +13,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv7ucc73fwrk3iltehus-fvqtmwcp50knma0zl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma0zl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 /* greek-ext */
@@ -22,7 +22,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv7ucc73fwrk3iltehus-fvqtmwcp50knma2zl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2zl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+1F00-1FFF;
 }
 /* greek */
@@ -31,7 +31,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv7ucc73fwrk3iltehus-fvqtmwcp50knma1pl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma1pl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0370-03FF;
 }
 /* vietnamese */
@@ -40,7 +40,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv7ucc73fwrk3iltehus-fvqtmwcp50knma2pl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2pl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
 /* latin-ext */
@@ -49,7 +49,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv7ucc73fwrk3iltehus-fvqtmwcp50knma25l7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma25l7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
@@ -58,7 +58,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv7ucc73fwrk3iltehus-fvqtmwcp50knma1zl7w0q5nw.woff2) format('woff2');
+  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma1zl7w0q5nw.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 /* cyrillic-ext */
@@ -67,7 +67,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv7ucc73fwrk3iltehus-fvqtmwcp50knma2jl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2jl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 /* cyrillic */
@@ -76,7 +76,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv7ucc73fwrk3iltehus-fvqtmwcp50knma0zl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma0zl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 /* greek-ext */
@@ -85,7 +85,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv7ucc73fwrk3iltehus-fvqtmwcp50knma2zl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2zl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+1F00-1FFF;
 }
 /* greek */
@@ -94,7 +94,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv7ucc73fwrk3iltehus-fvqtmwcp50knma1pl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma1pl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0370-03FF;
 }
 /* vietnamese */
@@ -103,7 +103,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv7ucc73fwrk3iltehus-fvqtmwcp50knma2pl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2pl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
 /* latin-ext */
@@ -112,7 +112,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv7ucc73fwrk3iltehus-fvqtmwcp50knma25l7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma25l7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
@@ -121,6 +121,6 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv7ucc73fwrk3iltehus-fvqtmwcp50knma1zl7w0q5nw.woff2) format('woff2');
+  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma1zl7w0q5nw.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/tests/__snapshots__/files/GoogleFontsTest__it_loads_google_fonts__1.css
+++ b/tests/__snapshots__/files/GoogleFontsTest__it_loads_google_fonts__1.css
@@ -4,7 +4,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2jl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2jl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 /* cyrillic */
@@ -13,7 +13,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma0zl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma0zl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 /* greek-ext */
@@ -22,7 +22,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2zl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2zl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+1F00-1FFF;
 }
 /* greek */
@@ -31,7 +31,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma1pl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma1pl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0370-03FF;
 }
 /* vietnamese */
@@ -40,7 +40,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2pl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2pl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
 /* latin-ext */
@@ -49,7 +49,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma25l7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma25l7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
@@ -58,7 +58,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma1zl7w0q5nw.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma1zl7w0q5nw.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 /* cyrillic-ext */
@@ -67,7 +67,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2jl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2jl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 /* cyrillic */
@@ -76,7 +76,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma0zl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma0zl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 /* greek-ext */
@@ -85,7 +85,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2zl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2zl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+1F00-1FFF;
 }
 /* greek */
@@ -94,7 +94,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma1pl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma1pl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0370-03FF;
 }
 /* vietnamese */
@@ -103,7 +103,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2pl7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma2pl7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
 /* latin-ext */
@@ -112,7 +112,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma25l7w0q5n-wu.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma25l7w0q5n-wu.woff2) format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
@@ -121,6 +121,6 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(/storage//952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma1zl7w0q5nw.woff2) format('woff2');
+  src: url(/storage/952ee985ef/sinterv8ucc73fwrk3iltehus-fvqtmwcp50knma1zl7w0q5nw.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }


### PR DESCRIPTION
This PR implements the idea suggested at https://github.com/spatie/laravel-google-fonts/discussions/22

The blocking option determines whether the rendering of the page should be blocked while loading the font or whether the font can also be applied after the page has loaded.