### PR TITLE
add nonce option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ return [
     @googlefonts
 
     {{-- Loads IBM Plex Mono --}}
-    @googlefonts(['font' => 'code'])
+    @googlefonts('code')
 </head>
 ```
 
@@ -135,9 +135,9 @@ return [
 <head>
     {{-- Loads Inter --}}
     @googlefonts
-
+    
     {{-- Loads IBM Plex Mono --}}
-    @googlefonts(['font' => 'code'])
+    @googlefonts('code')
 </head>
 ```
 
@@ -157,7 +157,7 @@ php artisan google-fonts:fetch
 
 ## Usage with spatie/laravel-csp
 
-If you're using [spatie/laravel-csp](https://github.com/spatie/laravel-csp) to manage your Content Security Policy, you can add the `nonce` option to the blade directive.
+If you're using [spatie/laravel-csp](https://github.com/spatie/laravel-csp) to manage your Content Security Policy, you can pass an array to the blade directive and add the `nonce` option.
 
 ```blade
 {{-- resources/views/layouts/app.blade.php --}}

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ return [
     @googlefonts
 
     {{-- Loads IBM Plex Mono --}}
-    @googlefonts('code')
+    @googlefonts(['font' => 'code'])
 </head>
 ```
 
@@ -137,7 +137,7 @@ return [
     @googlefonts
 
     {{-- Loads IBM Plex Mono --}}
-    @googlefonts('code')
+    @googlefonts(['font' => 'code'])
 </head>
 ```
 
@@ -153,6 +153,22 @@ If you want to make sure fonts are ready to go before anyone visits your site, y
 
 ```bash
 php artisan google-fonts:fetch
+```
+
+## Usage with spatie/laravel-csp
+
+If you're using [spatie/laravel-csp](https://github.com/spatie/laravel-csp) to manage your Content Security Policy, you can add the `nonce` option to the blade directive.
+
+```blade
+{{-- resources/views/layouts/app.blade.php --}}
+
+<head>
+    {{-- Loads Inter --}}
+    @googlefonts(['nonce' => csp_nonce()])
+
+    {{-- Loads IBM Plex Mono --}}
+    @googlefonts(['font' => 'code', 'nonce' => csp_nonce()])
+</head>
 ```
 
 ### Caveats for legacy browsers

--- a/src/Commands/FetchGoogleFontsCommand.php
+++ b/src/Commands/FetchGoogleFontsCommand.php
@@ -20,7 +20,7 @@ class FetchGoogleFontsCommand extends Command
             ->each(function (string $font) {
                 $this->info("Fetching `{$font}`...");
 
-                app(GoogleFonts::class)->load($font, forceDownload: true);
+                app(GoogleFonts::class)->load(compact('font'), forceDownload: true);
             });
 
         $this->info('All done!');

--- a/src/Fonts.php
+++ b/src/Fonts.php
@@ -3,50 +3,71 @@
 namespace Spatie\GoogleFonts;
 
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
 
 class Fonts implements Htmlable
 {
     public function __construct(
-        protected string $googleFontsUrl,
+        protected string  $googleFontsUrl,
         protected ?string $localizedUrl = null,
         protected ?string $localizedCss = null,
-        protected bool $preferInline = false,
-    ) {
+        protected ?string $nonce = null,
+        protected bool    $preferInline = false,
+    )
+    {
     }
 
     public function inline(): HtmlString
     {
-        if (! $this->localizedCss) {
+        if (!$this->localizedCss) {
             return $this->fallback();
         }
 
+        $attributes = $this->parseAttributes([
+            'nonce' => $this->nonce ?? false,
+        ]);
+
         return new HtmlString(<<<HTML
-            <style>{$this->localizedCss}</style>
+            <style {$attributes->implode(' ')}>{$this->localizedCss}</style>
         HTML);
     }
 
     public function link(): HtmlString
     {
-        if (! $this->localizedUrl) {
+        if (!$this->localizedUrl) {
             return $this->fallback();
         }
 
+        $attributes = $this->parseAttributes([
+            'href' => $this->localizedUrl,
+            'rel' => 'stylesheet',
+            'type' => 'text/css',
+            'nonce' => $this->nonce ?? false,
+        ]);
+
         return new HtmlString(<<<HTML
-            <link href="{$this->localizedUrl}" rel="stylesheet" type="text/css">
+            <link {$attributes->implode(' ')}>
         HTML);
     }
 
     public function fallback(): HtmlString
     {
+        $attributes = $this->parseAttributes([
+            'href' => $this->googleFontsUrl,
+            'rel' => 'stylesheet',
+            'type' => 'text/css',
+            'nonce' => $this->nonce ?? false,
+        ]);
+
         return new HtmlString(<<<HTML
-            <link href="{$this->googleFontsUrl}" rel="stylesheet" type="text/css">
+            <link {$attributes->implode(' ')}>
         HTML);
     }
 
     public function url(): string
     {
-        if (! $this->localizedUrl) {
+        if (!$this->localizedUrl) {
             return $this->googleFontsUrl;
         }
 
@@ -56,5 +77,14 @@ class Fonts implements Htmlable
     public function toHtml(): HtmlString
     {
         return $this->preferInline ? $this->inline() : $this->link();
+    }
+
+    protected function parseAttributes($attributes): Collection
+    {
+        return Collection::make($attributes)
+            ->reject(fn ($value, $key) => in_array($value, [false, null], true))
+            ->flatMap(fn ($value, $key) => $value === true ? [$key] : [$key => $value])
+            ->map(fn ($value, $key) => is_int($key) ? $value : $key . '="' . $value . '"')
+            ->values();
     }
 }

--- a/src/GoogleFonts.php
+++ b/src/GoogleFonts.php
@@ -20,11 +20,11 @@ class GoogleFonts
     ) {
     }
 
-    public function load(array $options = [], bool $forceDownload = false): Fonts
+    public function load(string|array $options = [], bool $forceDownload = false): Fonts
     {
         ['font' => $font, 'nonce' => $nonce] = $this->parseOptions($options);
 
-        if (! isset($this->fonts[$font])) {
+        if (!isset($this->fonts[$font])) {
             throw new RuntimeException("Font `{$font}` doesn't exist");
         }
 
@@ -37,13 +37,13 @@ class GoogleFonts
 
             $fonts = $this->loadLocal($url, $nonce);
 
-            if (! $fonts) {
+            if (!$fonts) {
                 return $this->fetch($url, $nonce);
             }
 
             return $fonts;
         } catch (Exception $exception) {
-            if (! $this->fallback) {
+            if (!$this->fallback) {
                 throw $exception;
             }
 
@@ -53,7 +53,7 @@ class GoogleFonts
 
     protected function loadLocal(string $url, ?string $nonce): ?Fonts
     {
-        if (! $this->filesystem->exists($this->path($url, 'fonts.css'))) {
+        if (!$this->filesystem->exists($this->path($url, 'fonts.css'))) {
             return null;
         }
 
@@ -128,8 +128,12 @@ class GoogleFonts
         return $segments->filter()->join('/');
     }
 
-    protected function parseOptions(array $options): array
+    protected function parseOptions(string|array $options): array
     {
+        if (is_string($options)) {
+            $options = ['font' => $options, 'nonce' => null];
+        }
+
         return [
             'font' => $options['font'] ?? 'default',
             'nonce' => $options['nonce'] ?? null,

--- a/tests/GoogleFontsTest.php
+++ b/tests/GoogleFontsTest.php
@@ -6,8 +6,9 @@ use Spatie\GoogleFonts\GoogleFonts;
 use function Spatie\Snapshots\assertMatchesFileSnapshot;
 use function Spatie\Snapshots\assertMatchesHtmlSnapshot;
 
-it('loads google fonts', function () {
-    $fonts = app(GoogleFonts::class)->load(['font' => 'inter'], forceDownload: true);
+
+it('loads google fonts', function ($arguments) {
+    $fonts = app(GoogleFonts::class)->load($arguments, forceDownload: true);
 
     $expectedFileName = '952ee985ef/fonts.css';
 
@@ -23,18 +24,21 @@ it('loads google fonts', function () {
 
     expect($woff2FileCount)->toBeGreaterThan(0);
 
-    assertMatchesHtmlSnapshot((string)$fonts->link());
-    assertMatchesHtmlSnapshot((string)$fonts->inline());
+    assertMatchesHtmlSnapshot((string) $fonts->link());
+    assertMatchesHtmlSnapshot((string) $fonts->inline());
 
     $expectedUrl = $this->disk()->url($expectedFileName);
     expect($fonts->url())->toEqual($expectedUrl);
-});
+})->with([
+    'font_as_string' => 'inter',
+    'font_as_array' => ['font' => 'inter'],
+]);
 
-it('falls back to google fonts', function () {
+it('falls back to google fonts', function ($arguments) {
     config()->set('google-fonts.fonts', ['cow' => 'moo']);
     config()->set('google-fonts.fallback', true);
 
-    $fonts = app(GoogleFonts::class)->load(['font' => 'cow'], forceDownload: true);
+    $fonts = app(GoogleFonts::class)->load($arguments, forceDownload: true);
 
     $allFiles = $this->disk()->allFiles();
 
@@ -45,11 +49,15 @@ it('falls back to google fonts', function () {
         HTML;
 
     expect([
-        (string)$fonts->link(),
-        (string)$fonts->inline(),
+        (string) $fonts->link(),
+        (string) $fonts->inline(),
     ])->each->toEqual($fallback)
         ->and($fonts->url())->toEqual('moo');
-});
+})
+    ->with([
+        'font_as_string' => 'cow',
+        'font_as_array' => ['font' => 'cow'],
+    ]);;
 
 it('adds the nonce attribute when specified', function () {
     config()->set('google-fonts.fonts', ['cow' => 'moo']);
@@ -58,7 +66,7 @@ it('adds the nonce attribute when specified', function () {
     $fonts = app(GoogleFonts::class)->load(['font' => 'cow', 'nonce' => 'chicken'], forceDownload: true);
 
     expect([
-        (string)$fonts->link(),
-        (string)$fonts->inline(),
+        (string) $fonts->link(),
+        (string) $fonts->inline(),
     ])->each->toContain('nonce="chicken"');
 });

--- a/tests/GoogleFontsTest.php
+++ b/tests/GoogleFontsTest.php
@@ -7,7 +7,7 @@ use function Spatie\Snapshots\assertMatchesFileSnapshot;
 use function Spatie\Snapshots\assertMatchesHtmlSnapshot;
 
 it('loads google fonts', function () {
-    $fonts = app(GoogleFonts::class)->load('inter', forceDownload: true);
+    $fonts = app(GoogleFonts::class)->load(['font' => 'inter'], forceDownload: true);
 
     $expectedFileName = '952ee985ef/fonts.css';
 
@@ -34,7 +34,7 @@ it('falls back to google fonts', function () {
     config()->set('google-fonts.fonts', ['cow' => 'moo']);
     config()->set('google-fonts.fallback', true);
 
-    $fonts = app(GoogleFonts::class)->load('cow', forceDownload: true);
+    $fonts = app(GoogleFonts::class)->load(['font' => 'cow'], forceDownload: true);
 
     $allFiles = $this->disk()->allFiles();
 
@@ -49,4 +49,16 @@ it('falls back to google fonts', function () {
         (string)$fonts->inline(),
     ])->each->toEqual($fallback)
         ->and($fonts->url())->toEqual('moo');
+});
+
+it('adds the nonce attribute when specified', function () {
+    config()->set('google-fonts.fonts', ['cow' => 'moo']);
+    config()->set('google-fonts.fallback', true);
+
+    $fonts = app(GoogleFonts::class)->load(['font' => 'cow', 'nonce' => 'chicken'], forceDownload: true);
+
+    expect([
+        (string)$fonts->link(),
+        (string)$fonts->inline(),
+    ])->each->toContain('nonce="chicken"');
 });

--- a/tests/__snapshots__/GoogleFontsTest__it_loads_google_fonts_with_data_set_font_as_array__2.html
+++ b/tests/__snapshots__/GoogleFontsTest__it_loads_google_fonts_with_data_set_font_as_array__2.html
@@ -1,0 +1,1 @@
+<html><head><link href="/storage/952ee985ef/fonts.css" rel="stylesheet" type="text/css"></head></html>

--- a/tests/__snapshots__/GoogleFontsTest__it_loads_google_fonts_with_data_set_font_as_array__3.html
+++ b/tests/__snapshots__/GoogleFontsTest__it_loads_google_fonts_with_data_set_font_as_array__3.html
@@ -1,0 +1,127 @@
+<html><head><style>/* cyrillic-ext */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma2jl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+/* cyrillic */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma0zl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+/* greek-ext */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma2zl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+1F00-1FFF;
+}
+/* greek */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma1pl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0370-03FF;
+}
+/* vietnamese */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma2pl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+}
+/* latin-ext */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma25l7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma1zl7w0q5nw.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+/* cyrillic-ext */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma2jl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+/* cyrillic */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma0zl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+/* greek-ext */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma2zl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+1F00-1FFF;
+}
+/* greek */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma1pl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0370-03FF;
+}
+/* vietnamese */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma2pl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+}
+/* latin-ext */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma25l7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma1zl7w0q5nw.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+</style></head></html>

--- a/tests/__snapshots__/GoogleFontsTest__it_loads_google_fonts_with_data_set_font_as_string__2.html
+++ b/tests/__snapshots__/GoogleFontsTest__it_loads_google_fonts_with_data_set_font_as_string__2.html
@@ -1,0 +1,1 @@
+<html><head><link href="/storage/952ee985ef/fonts.css" rel="stylesheet" type="text/css"></head></html>

--- a/tests/__snapshots__/GoogleFontsTest__it_loads_google_fonts_with_data_set_font_as_string__3.html
+++ b/tests/__snapshots__/GoogleFontsTest__it_loads_google_fonts_with_data_set_font_as_string__3.html
@@ -1,0 +1,127 @@
+<html><head><style>/* cyrillic-ext */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma2jl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+/* cyrillic */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma0zl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+/* greek-ext */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma2zl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+1F00-1FFF;
+}
+/* greek */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma1pl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0370-03FF;
+}
+/* vietnamese */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma2pl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+}
+/* latin-ext */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma25l7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma1zl7w0q5nw.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+/* cyrillic-ext */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma2jl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+/* cyrillic */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma0zl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+/* greek-ext */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma2zl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+1F00-1FFF;
+}
+/* greek */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma1pl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0370-03FF;
+}
+/* vietnamese */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma2pl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+}
+/* latin-ext */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma25l7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma1zl7w0q5nw.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+</style></head></html>

--- a/tests/__snapshots__/files/GoogleFontsTest__it_loads_google_fonts_with_data_set_font_as_array__1.css
+++ b/tests/__snapshots__/files/GoogleFontsTest__it_loads_google_fonts_with_data_set_font_as_array__1.css
@@ -1,0 +1,126 @@
+/* cyrillic-ext */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma2jl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+/* cyrillic */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma0zl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+/* greek-ext */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma2zl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+1F00-1FFF;
+}
+/* greek */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma1pl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0370-03FF;
+}
+/* vietnamese */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma2pl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+}
+/* latin-ext */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma25l7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma1zl7w0q5nw.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+/* cyrillic-ext */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma2jl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+/* cyrillic */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma0zl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+/* greek-ext */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma2zl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+1F00-1FFF;
+}
+/* greek */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma1pl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0370-03FF;
+}
+/* vietnamese */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma2pl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+}
+/* latin-ext */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma25l7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma1zl7w0q5nw.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}

--- a/tests/__snapshots__/files/GoogleFontsTest__it_loads_google_fonts_with_data_set_font_as_string__1.css
+++ b/tests/__snapshots__/files/GoogleFontsTest__it_loads_google_fonts_with_data_set_font_as_string__1.css
@@ -1,0 +1,126 @@
+/* cyrillic-ext */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma2jl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+/* cyrillic */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma0zl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+/* greek-ext */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma2zl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+1F00-1FFF;
+}
+/* greek */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma1pl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0370-03FF;
+}
+/* vietnamese */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma2pl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+}
+/* latin-ext */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma25l7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma1zl7w0q5nw.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+/* cyrillic-ext */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma2jl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+/* cyrillic */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma0zl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+/* greek-ext */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma2zl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+1F00-1FFF;
+}
+/* greek */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma1pl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0370-03FF;
+}
+/* vietnamese */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma2pl7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+}
+/* latin-ext */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma25l7w0q5n-wu.woff2) format('woff2');
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(/storage/952ee985ef/sinterv12ucc73fwrk3iltehus-fvqtmwcp50knma1zl7w0q5nw.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}


### PR DESCRIPTION
Hi Spatie, thanks for creating this awesome package, but I noticed there was no way to integrate the [spatie/laravel-csp](https://github.com/spatie/laravel-csp) package with this one. I have made some changes so the `@googlefonts` directive accepts an array of options just like the Livewire package does.

I guess it's kind of a breaking change because you need to update the directive from:

```blade
@googlefonts('code')
```

to:
```blade
@googlefonts(['font' => 'code', 'nonce' => csp_nonce()])
```

Let me know what you think!