### PR TITLE
Fix issues with font URLs without a ".woff2" extension.

### DIFF
--- a/src/GoogleFonts.php
+++ b/src/GoogleFonts.php
@@ -127,7 +127,12 @@ class GoogleFonts
 
     protected function localizeFontUrl(string $path): string
     {
-        [$path, $extension] = explode('.', str_replace('https://fonts.gstatic.com/', '', $path));
+        // Google Fonts seem to have recently changed their URL structure to one that no longer contains a file
+        // extension (see https://github.com/spatie/laravel-google-fonts/issues/40). We account for that by falling back
+        // to 'woff2' in that case.
+        $pathComponents = explode('.', str_replace('https://fonts.gstatic.com/', '', $path));
+        $path = $pathComponents[0];
+        $extension = $pathComponents[1] ?? 'woff2';
 
         return implode('.', [Str::slug($path), $extension]);
     }


### PR DESCRIPTION
Fixes https://github.com/spatie/laravel-google-fonts/issues/40. I have been encountering the same issue, resulting in an "Undefined array key 1" error. This PR fixes that.

I would have also updated the tests for this, but it seems like the HTTP requests to Google Fonts are currently not being mocked.
