### PR TITLE
Remove duplicate matched URLs

### DIFF
--- a/src/GoogleFonts.php
+++ b/src/GoogleFonts.php
@@ -122,7 +122,7 @@ class GoogleFonts
         $matches = [];
         preg_match_all('/url\((https:\/\/fonts.gstatic.com\/[^)]+)\)/', $css, $matches);
 
-        return $matches[1] ?? [];
+        return array_unique($matches[1] ?? []);
     }
 
     protected function localizeFontUrl(string $path): string


### PR DESCRIPTION
I noticed that when processing the following font URL:

https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,500,500italic,600,600italic,700,700italic,800,800italic

the current logic at [GoogleFonts.php L123](https://github.com/spatie/laravel-google-fonts/blob/5c1db1884bdab88ef555d82ecbabbc81fc131766/src/GoogleFonts.php#L123) matches 120 URLs. However, only 20 of these URLs are unique. As a result, the implementation ends up downloading 100 redundant URLs.

I noticed duplicates in other CSS files too, even the ones shown in the documentation.

This pull request updates the logic to ensure that only unique URLs are processed and downloaded, which should optimize performance and reduce unnecessary network requests.

Looking forward to your feedback!