### PR TITLE
Fix: preload tags now reference localized font files instead of Google Fonts URL

### DIFF
--- a/src/GoogleFonts.php
+++ b/src/GoogleFonts.php
@@ -95,7 +95,7 @@ class GoogleFonts
             );
 
             $localizedUrl = $this->filesystem->url($this->path($url, $localizedFontUrl));
-            $preloadMeta .= $this->getPreload($url) . "\n";
+            $preloadMeta .= $this->getPreload($localizedUrl) . "\n";
             $localizedCss = str_replace(
                 $fontUrl,
                 $localizedUrl,


### PR DESCRIPTION
## Fix: preload tags now reference localized font files instead of Google Fonts CSS

### Problem
When generating `preload.html`, the package currently inserts multiple `<link rel="preload">` tags pointing to the **Google Fonts CSS URL** (e.g. `https://fonts.googleapis.com/css2?family=Montserrat...`) instead of the actual font files.

Example of incorrect output:
```html
<link rel="preload" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" as="font" type="font/woff2" crossorigin>
<link rel="preload" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" as="font" type="font/woff2" crossorigin>
```

This leads to:
* Preloading of the CSS resource instead of the actual `.woff2` font files.
* Browsers not benefiting from the preload, since the CSS is already fetched separately.

### Solution
In `GoogleFonts::fetch()`, the generated preload tags now reference the **localized font file URLs** (`.woff2` in `storage/fonts/...`) instead of the CSS URL.

```diff
- $preloadMeta .= $this->getPreload($url) . "\n";
+ $preloadMeta .= $this->getPreload($localizedUrl) . "\n";
```

### Result
`preload.html` now contains correct links:

```html
<link rel="preload" href="https://example.com/storage/fonts/485c88d4d2/smontserratv31jtusjig1-i6t8kchkm459wrhyyth89znpq.woff2" as="font" type="font/woff2" crossorigin>
<link rel="preload" href="https://example.com/storage/fonts/485c88d4d2/smontserratv31jtusjig1-i6t8kchkm459w1hyyth89znpq.woff2" as="font" type="font/woff2" crossorigin>
```