### PR TITLE
Allow lazy fetching (only for fonts not already fetched)

### DIFF
--- a/src/Commands/FetchGoogleFontsCommand.php
+++ b/src/Commands/FetchGoogleFontsCommand.php
@@ -13,8 +13,8 @@ class FetchGoogleFontsCommand extends Command
 
     public function handle()
     {
-        $newFontsOnly = $this->option('new-fonts-only') ?? false;
-        
+        $newFontsOnly = $this->option('new-fonts-only');
+
         $this->info('Start fetching Google Fonts...');
 
         collect(config('google-fonts.fonts'))

--- a/src/Commands/FetchGoogleFontsCommand.php
+++ b/src/Commands/FetchGoogleFontsCommand.php
@@ -7,20 +7,22 @@ use Spatie\GoogleFonts\GoogleFonts;
 
 class FetchGoogleFontsCommand extends Command
 {
-    public $signature = 'google-fonts:fetch';
+    public $signature = 'google-fonts:fetch {--new-fonts-only : only download the fonts which are not already cached}';
 
     public $description = 'Fetch Google Fonts and store them on a local disk';
 
     public function handle()
     {
+        $newFontsOnly = $this->option('new-fonts-only') ?? false;
+        
         $this->info('Start fetching Google Fonts...');
 
         collect(config('google-fonts.fonts'))
             ->keys()
-            ->each(function (string $font) {
+            ->each(function (string $font) use ($newFontsOnly) {
                 $this->info("Fetching `{$font}`...");
 
-                app(GoogleFonts::class)->load(compact('font'), forceDownload: true);
+                app(GoogleFonts::class)->load(compact('font'), forceDownload: !$newFontsOnly);
             });
 
         $this->info('All done!');

--- a/src/Commands/FetchGoogleFontsCommand.php
+++ b/src/Commands/FetchGoogleFontsCommand.php
@@ -22,7 +22,7 @@ class FetchGoogleFontsCommand extends Command
             ->each(function (string $font) use ($newFontsOnly) {
                 $this->info("Fetching `{$font}`...");
 
-                app(GoogleFonts::class)->load(compact('font'), forceDownload: !$newFontsOnly);
+                app(GoogleFonts::class)->load(compact('font'), forceDownload: ! $newFontsOnly);
             });
 
         $this->info('All done!');

--- a/tests/Commands/FetchGoogleFontsCommandTest.php
+++ b/tests/Commands/FetchGoogleFontsCommandTest.php
@@ -19,3 +19,11 @@ it('will use the configured path when fetching fonts', function () {
 
     $this->disk()->assertExists("{$path}/952ee985ef/fonts.css");
 });
+
+it('skips already-fetched fonts when --new-fonts-only is passed', function () {
+    $this->disk()->put('952ee985ef/fonts.css', 'cached-css');
+
+    $this->artisan(FetchGoogleFontsCommand::class, ['--new-fonts-only' => true]);
+
+    expect($this->disk()->get('952ee985ef/fonts.css'))->toBe('cached-css');
+});


### PR DESCRIPTION
This is to allow only fetching missing fonts (https://github.com/spatie/laravel-google-fonts/discussions/59).

For simplicity this does not cleanup when fonts are removed from the configuration.